### PR TITLE
[TEST] 10 유저서버 테스트코드 작성 유저관련 api

### DIFF
--- a/test/v1/apis/friends/friends.service.spec.ts
+++ b/test/v1/apis/friends/friends.service.spec.ts
@@ -1,14 +1,14 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
-import { STATUS } from '../../../../../src/v1/common/constants/status.js';
+import { STATUS } from '../../../../src/v1/common/constants/status.js';
 import {
   NotFoundException,
   ConflictException,
   BadRequestException,
-} from '../../../../../src/v1/common/exceptions/core.error.js';
+} from '../../../../src/v1/common/exceptions/core.error.js';
 import { Status } from '@prisma/client';
-import FriendRepositoryInterface from '../../../../../src/v1/storage/database/interfaces/friend.repository.interface.js';
-import UserRepositoryInterface from '../../../../../src/v1/storage/database/interfaces/user.repository.interface.js';
-import FriendsService from '../../../../../src/v1/apis/friends/friends.service.js';
+import FriendRepositoryInterface from '../../../../src/v1/storage/database/interfaces/friend.repository.interface.js';
+import UserRepositoryInterface from '../../../../src/v1/storage/database/interfaces/user.repository.interface.js';
+import FriendsService from '../../../../src/v1/apis/friends/friends.service.js';
 
 const mockUserRepository: UserRepositoryInterface = {
   create: vi.fn(),

--- a/test/v1/apis/users/users.service.spec.ts
+++ b/test/v1/apis/users/users.service.spec.ts
@@ -1,0 +1,160 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import UsersService from '../../../../src/v1/apis/users/users.service.js';
+import { STATUS } from '../../../../src/v1/common/constants/status.js';
+import {
+  ConflictException,
+  NotFoundException,
+  UnAuthorizedException,
+} from '../../../../src/v1/common/exceptions/core.error.js';
+import bcrypt from 'bcrypt';
+import UserRepositoryInterface from '../../../../src/v1/storage/database/interfaces/user.repository.interface.js';
+import UserRepositoryPrisma from '../../../../src/v1/storage/database/prisma/user.repository.js';
+import mockPrisma from '../../mocks/mockPrisma.js';
+
+let userRepository: UserRepositoryInterface;
+let usersService: UsersService;
+
+beforeEach(() => {
+  userRepository = new UserRepositoryPrisma(mockPrisma);
+
+  usersService = new UsersService(userRepository, bcrypt);
+});
+
+describe('회원가입', () => {
+  it('정상', async () => {
+    userRepository.findByEmail = vi.fn().mockResolvedValue(null);
+    userRepository.create = vi.fn().mockResolvedValue({
+      id: 1,
+      email: 'test@naver.com',
+      nickname: 'tester',
+    });
+
+    const result = await usersService.createUser({
+      email: 'test@naver.com',
+      password: '1234',
+      nickname: 'tester',
+    });
+
+    expect(result.status).toBe(STATUS.SUCCESS);
+    expect(result.data!.email).toBe('test@naver.com');
+  });
+
+  it('중복 이메일', async () => {
+    userRepository.findByEmail = vi.fn().mockResolvedValue({ id: 1 });
+
+    await expect(
+      usersService.createUser({
+        email: 'test@naver.com',
+        password: '1234',
+        nickname: 'tester',
+      }),
+    ).rejects.toThrow(ConflictException);
+  });
+});
+
+describe('로그인', () => {
+  it('정상', async () => {
+    const passwordHash = await bcrypt.hash('1234', 10);
+    userRepository.findByEmail = vi.fn().mockResolvedValue({
+      id: 1,
+      passwordHash,
+    });
+
+    const result = await usersService.authenticateUser({
+      email: 'test@naver.com',
+      password: '1234',
+    });
+
+    expect(result.status).toBe(STATUS.SUCCESS);
+    expect(result.message).toBe('로그인 성공');
+  });
+
+  it('유저 없음 또는 비밀번호 없음', async () => {
+    userRepository.findByEmail = vi.fn().mockResolvedValue(null);
+
+    await expect(
+      usersService.authenticateUser({
+        email: 'test@naver.com',
+        password: '1234',
+      }),
+    ).rejects.toThrow(UnAuthorizedException);
+  });
+
+  it('비밀번호 틀림', async () => {
+    const passwordHash = await bcrypt.hash('wrongpassword', 10);
+    userRepository.findByEmail = vi.fn().mockResolvedValue({ id: 1, passwordHash });
+
+    await expect(
+      usersService.authenticateUser({
+        email: 'test@naver.com',
+        password: '1234',
+      }),
+    ).rejects.toThrow(UnAuthorizedException);
+  });
+});
+
+describe('유저 조회', () => {
+  it('정상', async () => {
+    userRepository.findById = vi.fn().mockResolvedValue({
+      id: 1,
+      email: 'test@naver.com',
+      nickname: 'tester',
+    });
+
+    const result = await usersService.getUser(1);
+
+    expect(result.status).toBe(STATUS.SUCCESS);
+    expect(result.data!.id).toBe(1);
+  });
+
+  it('존재하지 않는 유저', async () => {
+    userRepository.findById = vi.fn().mockResolvedValue(null);
+
+    await expect(usersService.getUser(999)).rejects.toThrow(NotFoundException);
+  });
+});
+
+describe('닉네임 수정', () => {
+  it('정상', async () => {
+    userRepository.update = vi.fn().mockResolvedValue({
+      id: 1,
+      nickname: 'newNick',
+    });
+
+    const result = await usersService.editNickname(1, { nickname: 'newNick' });
+
+    expect(result.status).toBe(STATUS.SUCCESS);
+    expect(result.data!.nickname).toBe('newNick');
+  });
+
+  it('유저 ID 없음', async () => {
+    await expect(usersService.editNickname(undefined, { nickname: 'test' })).rejects.toThrow(
+      NotFoundException,
+    );
+  });
+
+  it('업데이트 실패', async () => {
+    userRepository.update = vi.fn().mockResolvedValue(null);
+
+    await expect(usersService.editNickname(1, { nickname: 'test' })).rejects.toThrow(
+      NotFoundException,
+    );
+  });
+});
+
+describe('유저 검색', () => {
+  it('정상', async () => {
+    const mockUsers = [
+      { id: 1, nickname: 'test1' },
+      { id: 2, nickname: 'test2' },
+    ];
+    userRepository.findByNicknameStartsWith = vi.fn().mockResolvedValue(mockUsers);
+
+    const result = await usersService.searchUser('test');
+
+    expect(result.status).toBe(STATUS.SUCCESS);
+    expect(result.data).toBeDefined();
+    expect(result.data!.length).toBe(2);
+    expect(result.data![0].nickname).toMatch(/^test/);
+  });
+});


### PR DESCRIPTION
## 🔗 반영 브랜치

#10 [test/10-유저서버-테스트코드-작성-유저관련-api](https://github.com/42-Gang/user-server/compare/dev...test/10-%EC%9C%A0%EC%A0%80%EC%84%9C%EB%B2%84-%ED%85%8C%EC%8A%A4%ED%8A%B8%EC%BD%94%EB%93%9C-%EC%9E%91%EC%84%B1-%EC%9C%A0%EC%A0%80%EA%B4%80%EB%A0%A8-api?expand=1) -> dev

## 📝 작업 내용

유저관련 API 테스트 코드를 작성했습니다.
Converage는 service코드만 100%로 맞춰두었습니다.

### 📸 스크린샷 (선택)

<img width="763" alt="image" src="https://github.com/user-attachments/assets/4ac705a9-78cb-4e47-8c5c-219e3e045b7b" />
