### PR TITLE
[REFACTOR] 15 사용자 실시간 상태 기능 수정

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -30,26 +30,26 @@ function setMiddleware(fastify: FastifyInstance) {
     if (authenticated === undefined || Array.isArray(authenticated)) {
       request.authenticated = false;
       request.userId = undefined;
-      done();
+      return done();
     }
 
     if (userId === undefined || Array.isArray(userId)) {
       request.authenticated = false;
       request.userId = undefined;
-      done();
+      return done();
     }
 
     if (isNaN(Number(userId))) {
       request.authenticated = false;
       request.userId = undefined;
-      done();
+      return done();
     }
 
     if (authenticated === 'true') {
       request.authenticated = true;
       request.userId = parseInt(userId as string, 10);
     }
-    done();
+    return done();
   });
 }
 

--- a/src/plugins/http.client.ts
+++ b/src/plugins/http.client.ts
@@ -8,7 +8,7 @@ interface HttpRequestOptions {
   headers?: Record<string, string>;
 }
 
-class GotClient {
+export class GotClient {
   client: Got;
 
   constructor(options?: ExtendOptions) {
@@ -29,4 +29,8 @@ class GotClient {
   }
 }
 
-export const gotClient = new GotClient();
+export const gotClient = new GotClient({
+  get throwHttpErrors() {
+    return false;
+  },
+});

--- a/src/plugins/router.ts
+++ b/src/plugins/router.ts
@@ -16,6 +16,7 @@ export interface Route {
 
 export async function addRoutes(fastify: FastifyInstance, routes: Route[]) {
   routes.forEach((route) => {
+    // 권한 필요 없으면 그대로 등록
     if (route.options.auth === false) {
       fastify.route({
         method: route.method,
@@ -31,7 +32,7 @@ export async function addRoutes(fastify: FastifyInstance, routes: Route[]) {
       url: route.url,
       handler: route.handler,
       schema: route.options.schema,
-      onRequest: fastify.authenticate,
+      preHandler: fastify.authenticate, // ✅ 권한 확인 미들웨어
     });
   });
 }

--- a/src/plugins/socket.ts
+++ b/src/plugins/socket.ts
@@ -11,6 +11,7 @@ export function createSocketServer(fastify: FastifyInstance) {
     },
   });
   socket.logger = fastify.log;
+  socket.diContainer = fastify.diContainer;
 
   const pubClient = redis;
   const subClient = pubClient.duplicate();

--- a/src/v1/common/types/socket.d.ts
+++ b/src/v1/common/types/socket.d.ts
@@ -1,10 +1,12 @@
 import 'socket.io';
 import { FastifyBaseLogger } from 'fastify';
 import { RedisClient } from 'ioredis/built/connectors/SentinelConnector/types.js';
+import { AwilixContainer } from 'awilix';
 
 declare module 'socket.io' {
   interface Server {
     logger: FastifyBaseLogger;
+    diContainer: AwilixContainer;
     data: {
       userId: number;
     };

--- a/src/v1/sockets/status/friends.schema.ts
+++ b/src/v1/sockets/status/friends.schema.ts
@@ -1,7 +1,12 @@
 import { z } from 'zod';
+import { Status } from '@prisma/client';
 
 export const friendSchema = z.object({
   friendId: z.number(),
 });
 
 export const friendsSchema = z.array(friendSchema);
+
+export const statusSchema = z.object({
+  status: z.nativeEnum(Status),
+});

--- a/src/v1/sockets/status/status.namespace.ts
+++ b/src/v1/sockets/status/status.namespace.ts
@@ -1,17 +1,14 @@
 import { Namespace } from 'socket.io';
 import { socketMiddleware } from '../utils/middleware.js';
-import { redis } from '../../../plugins/redis.js';
 import { startConsumer } from './kafka/consumer.js';
-import FriendCacheRedis from '../../storage/cache/redis/friend.cache.repository.js';
-import StatusService from './status.service.js';
 import { handleConnection } from './connection.handler.js';
 
 export default async function statusNamespace(namespace: Namespace) {
   namespace.use(socketMiddleware);
-  const friendCacheRepository = new FriendCacheRedis(redis);
-  const statusService = new StatusService(friendCacheRepository);
+
+  const friendCacheRepository = namespace.server.diContainer.resolve('friendCacheRepository');
+  const statusService = namespace.server.diContainer.resolve('statusService');
 
   startConsumer(namespace, friendCacheRepository);
-
   namespace.on('connection', (socket) => handleConnection(socket, namespace, statusService));
 }

--- a/src/v1/sockets/status/status.service.ts
+++ b/src/v1/sockets/status/status.service.ts
@@ -28,16 +28,16 @@ export default class StatusService {
     userId: number;
     friendId: number;
   }): Promise<TypeOf<typeof statusSchema>> {
-    const foundUser = await this.friendRepository.findByUserIdAndFriendId({
+    const foundFriend = await this.friendRepository.findByUserIdAndFriendId({
       userId,
       friendId,
     });
-    if (!foundUser) {
+    if (!foundFriend) {
       throw new NotFoundException('Friend not found');
     }
 
     return {
-      status: foundUser.status,
+      status: foundFriend.status,
     };
   }
 }

--- a/src/v1/sockets/status/status.service.ts
+++ b/src/v1/sockets/status/status.service.ts
@@ -1,30 +1,19 @@
 import { FriendCacheInterface } from '../../storage/cache/interfaces/friend.cache.interface.js';
 import { friendsSchema } from './friends.schema.js';
 import { TypeOf } from 'zod';
-import { gotClient } from '../../../plugins/http.client.js';
-import * as console from 'node:console';
+import FriendRepositoryInterface from '../../storage/database/interfaces/friend.repository.interface.js';
 
 export default class StatusService {
-  constructor(private readonly friendCacheRepository: FriendCacheInterface) {}
+  constructor(
+    private readonly friendCacheRepository: FriendCacheInterface,
+    private readonly friendRepository: FriendRepositoryInterface,
+  ) {}
 
   async fetchFriends(userId: number): Promise<TypeOf<typeof friendsSchema>> {
-    const cachedFriends = await this.friendCacheRepository.getFriends(userId);
-    if (cachedFriends?.length) return cachedFriends;
+    // const cachedFriends = await this.friendCacheRepository.getFriends(userId);
+    // if (cachedFriends?.length) return cachedFriends;
 
-    // 나를 block 한 친구는 제외하고 가져오기 (추가)
-    const response = await gotClient.request<{
-      data: { friends: { id: number; friendId: number; nickname: string }[] };
-    }>({
-      method: 'GET',
-      url: `http://localhost:8080/api/v1/friends/${userId}`,
-      headers: {
-        'X-Authenticated': 'true',
-        'X-User-Id': userId.toString(),
-      },
-    });
-
-    const friends = response.body.data.friends ?? [];
-    console.log('friends', friends);
+    const friends = await this.friendRepository.findAllByUserIdAndStatus(userId, 'ACCEPTED');
 
     friendsSchema.parse(friends);
     await this.friendCacheRepository.addFriends(userId, friends);

--- a/src/v1/sockets/status/status.service.ts
+++ b/src/v1/sockets/status/status.service.ts
@@ -1,7 +1,8 @@
 import { FriendCacheInterface } from '../../storage/cache/interfaces/friend.cache.interface.js';
-import { friendsSchema } from './friends.schema.js';
+import { friendsSchema, statusSchema } from './friends.schema.js';
 import { TypeOf } from 'zod';
 import FriendRepositoryInterface from '../../storage/database/interfaces/friend.repository.interface.js';
+import { NotFoundException } from '../../common/exceptions/core.error.js';
 
 export default class StatusService {
   constructor(
@@ -18,5 +19,25 @@ export default class StatusService {
     friendsSchema.parse(friends);
     await this.friendCacheRepository.addFriends(userId, friends);
     return friends;
+  }
+
+  async fetchFriendStatus({
+    userId,
+    friendId,
+  }: {
+    userId: number;
+    friendId: number;
+  }): Promise<TypeOf<typeof statusSchema>> {
+    const foundUser = await this.friendRepository.findByUserIdAndFriendId({
+      userId,
+      friendId,
+    });
+    if (!foundUser) {
+      throw new NotFoundException('Friend not found');
+    }
+
+    return {
+      status: foundUser.status,
+    };
   }
 }

--- a/src/v1/sockets/utils/auth.ts
+++ b/src/v1/sockets/utils/auth.ts
@@ -1,12 +1,12 @@
 // utils/auth.ts
 import { gotClient } from '../../../plugins/http.client.js';
 
-export async function verifyAccessToken(token: string): Promise<boolean> {
+export async function verifyAccessToken(token: string): Promise<number> {
   const response = await gotClient.request({
     method: 'POST',
     url: 'http://localhost:8080/api/v1/auth/token/verify',
     body: { access_token: token },
   });
 
-  return response.statusCode === 200;
+  return response.statusCode;
 }

--- a/src/v1/sockets/utils/middleware.ts
+++ b/src/v1/sockets/utils/middleware.ts
@@ -12,8 +12,9 @@ export async function socketMiddleware(socket: Socket, next: NextFunction) {
       return next(new BadRequestException('유효하지 않은 토큰 형식입니다.'));
     }
 
-    const isVerified = await verifyAccessToken(token);
-    if (!isVerified) return next(new UnAuthorizedException('인증되지 않은 사용자입니다.'));
+    const responseStatus = await verifyAccessToken(token);
+    if (responseStatus !== 200)
+      return next(new UnAuthorizedException('인증되지 않은 사용자입니다.'));
 
     const { id } = decodeJwtPayload(token);
     socket.data.userId = id;

--- a/src/v1/sockets/utils/token.ts
+++ b/src/v1/sockets/utils/token.ts
@@ -1,4 +1,3 @@
-// utils/token.ts
 import { decode } from 'js-base64';
 import { BadRequestException } from '../../common/exceptions/core.error.js';
 

--- a/src/v1/storage/database/interfaces/friend.repository.interface.ts
+++ b/src/v1/storage/database/interfaces/friend.repository.interface.ts
@@ -14,4 +14,6 @@ export default interface FriendRepositoryInterface
     userId: number;
     friendId: number;
   }): Promise<friend | null>;
+
+  findAllByUserId(userId: number): Promise<friend[]>;
 }

--- a/src/v1/storage/database/prisma/friend.repository.ts
+++ b/src/v1/storage/database/prisma/friend.repository.ts
@@ -28,11 +28,21 @@ export default class FriendRepositoryPrisma implements FriendRepositoryInterface
     return this.prisma.friend.findMany({ where: { friendId, status } });
   }
 
-  findByUserIdAndFriendId(userId: number, friendId: number): Promise<Friend | null> {
+  findByUserIdAndFriendId({
+    userId,
+    friendId,
+  }: {
+    userId: number;
+    friendId: number;
+  }): Promise<Friend | null> {
     return this.prisma.friend.findFirst({ where: { userId, friendId } });
   }
 
   update(id: number, data: Prisma.FriendUpdateInput): Promise<Friend> {
     return this.prisma.friend.update({ where: { id }, data });
+  }
+
+  findAllByUserId(userId: number): Promise<Friend[]> {
+    return this.prisma.friend.findMany({ where: { userId } });
   }
 }


### PR DESCRIPTION
## 🔗 반영 브랜치

#15  [refactor/15-사용자-실시간-상태-기능-수정](https://github.com/42-Gang/user-server/compare/dev...refactor/15-%EC%82%AC%EC%9A%A9%EC%9E%90-%EC%8B%A4%EC%8B%9C%EA%B0%84-%EC%83%81%ED%83%9C-%EA%B8%B0%EB%8A%A5-%EC%88%98%EC%A0%95?expand=1) -> dev

## 📝 작업 내용

1. 유저서버의 websocket연결시 자신의 친구목록을 가져오는 부분을 수정했습니다(기존 코드에서는 친구서버와 통합되기 전이라 got을 사용하여 데이터를 가져왔습니다).
2. 상대방이 자신을 차단한 경우 상대방의 상태를 확인할 수 없도록 하였습니다. 
3. awilix를 소켓 서버에서 적용하였습니다. 