### PR TITLE
[REFACTOR] 26 유저검색 api 수정

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -1,7 +1,7 @@
 import { createServer, startServer } from './server-utils.js';
 import { configureServer, registerPlugins, setupGracefulShutdown } from './server-config.js';
 import { createSocketServer } from './plugins/socket.js';
-import { asClass, asFunction, asValue, Lifetime } from 'awilix';
+import { asClass, asFunction, Lifetime } from 'awilix';
 import { startConsumer } from './v1/kafka/consumer.js';
 
 async function init() {

--- a/src/v1/apis/friends/friends.route.ts
+++ b/src/v1/apis/friends/friends.route.ts
@@ -6,7 +6,7 @@ import {
   friendResponseSchema,
   updateFriendParamsSchema,
 } from './friends.schema.js';
-import { getFriendsQuerySchema } from './schemas/get-friends.schema.js';
+import { friendListResponseSchema, getFriendsQuerySchema } from './schemas/get-friends.schema.js';
 import { getStatusQuerySchema } from './schemas/get-status.schema.js';
 
 export default async function friendsRoutes(fastify: FastifyInstance) {
@@ -103,7 +103,7 @@ export default async function friendsRoutes(fastify: FastifyInstance) {
           description: '친구 리스트',
           querystring: getFriendsQuerySchema,
           response: {
-            200: friendResponseSchema,
+            200: friendListResponseSchema,
           },
         },
         auth: true,

--- a/src/v1/apis/users/schemas/search-user.schema.ts
+++ b/src/v1/apis/users/schemas/search-user.schema.ts
@@ -18,7 +18,12 @@ export const searchUserQuerySchema = z.object({
       }
       return [status];
     },
-    z.array(z.nativeEnum(Status)),
+    z.array(
+      z.nativeEnum({
+        ...Status,
+        NONE: 'NONE',
+      }),
+    ),
   ),
   exceptMe: z.boolean().optional(),
 });

--- a/src/v1/apis/users/schemas/search-user.schema.ts
+++ b/src/v1/apis/users/schemas/search-user.schema.ts
@@ -35,23 +35,12 @@ export const searchUserQuerySchema = z.object({
       })
       .optional(),
   ),
-  exceptMe: z.preprocess(
-    (num) => (num === undefined ? undefined : Number(num)),
-    z.preprocess(
-      (num) => (num === undefined ? undefined : Number(num)),
-      z
-        .number()
-        .optional()
-        .superRefine((val, ctx) => {
-          if (val !== undefined && val !== 0 && val !== 1) {
-            ctx.addIssue({
-              code: z.ZodIssueCode.custom,
-              message: 'exceptMe는 0, 1 또는 undefined만 가능합니다.',
-            });
-          }
-        }),
-    ),
-  ),
+  exceptMe: z.preprocess((val) => {
+    if (val === undefined) return undefined;
+    if (val === 'true' || val === 1) return true;
+    if (val === 'false' || val === 0) return false;
+    return val;
+  }, z.boolean().optional()),
 });
 
 export const searchUserResponseSchema = createResponseSchema(

--- a/src/v1/apis/users/schemas/search-user.schema.ts
+++ b/src/v1/apis/users/schemas/search-user.schema.ts
@@ -1,9 +1,23 @@
 import { exceptedSensitiveFields, userSchema } from './users.schema.js';
 import { createResponseSchema } from '../../../common/schema/core.schema.js';
 import { z } from 'zod';
+import { Status } from '@prisma/client';
 
 export const searchUserParamsSchema = userSchema.pick({
   nickname: true,
+});
+
+export const searchUserQuerySchema = z.object({
+  status: z.preprocess(
+    (status) => {
+      if (Array.isArray(status)) {
+        return status;
+      }
+      return [status];
+    },
+    z.array(z.nativeEnum(Status)),
+  ),
+  exceptMe: z.boolean().optional(),
 });
 
 export const searchUserResponseSchema = createResponseSchema(

--- a/src/v1/apis/users/schemas/search-user.schema.ts
+++ b/src/v1/apis/users/schemas/search-user.schema.ts
@@ -10,6 +10,9 @@ export const searchUserParamsSchema = userSchema.pick({
 export const searchUserQuerySchema = z.object({
   status: z.preprocess(
     (status) => {
+      if (status === undefined) {
+        return [];
+      }
       if (Array.isArray(status)) {
         return status;
       }

--- a/src/v1/apis/users/users.controller.ts
+++ b/src/v1/apis/users/users.controller.ts
@@ -40,7 +40,11 @@ export default class UsersController {
   searchUser = async (request: FastifyRequest, reply: FastifyReply) => {
     const query = searchUserQuerySchema.parse(request.query);
     const params = searchUserParamsSchema.parse(request.params);
-    const result = await this.usersService.searchUser(query, params.nickname);
+    const result = await this.usersService.searchUser({
+      userId: request.userId,
+      query,
+      nickname: params.nickname,
+    });
     reply.code(200).send(result);
   };
 

--- a/src/v1/apis/users/users.controller.ts
+++ b/src/v1/apis/users/users.controller.ts
@@ -38,8 +38,9 @@ export default class UsersController {
   };
 
   searchUser = async (request: FastifyRequest, reply: FastifyReply) => {
+    const query = searchUserParamsSchema.parse(request.query);
     const params = searchUserParamsSchema.parse(request.params);
-    const result = await this.usersService.searchUser(params.nickname);
+    const result = await this.usersService.searchUser(query, params.nickname);
     reply.code(200).send(result);
   };
 

--- a/src/v1/apis/users/users.controller.ts
+++ b/src/v1/apis/users/users.controller.ts
@@ -4,7 +4,7 @@ import UsersService from './users.service.js';
 import { createUserInputSchema } from './schemas/create-user.schema.js';
 import { getUserParamsSchema, getUserResponseSchema } from './schemas/get-user.schema.js';
 import { editNicknameInputSchema } from './schemas/edit-nickname.schema.js';
-import { searchUserParamsSchema } from './schemas/search-user.schema.js';
+import { searchUserParamsSchema, searchUserQuerySchema } from './schemas/search-user.schema.js';
 import { authenticateUserInputSchema } from './schemas/authenticate-user.schema.js';
 import { checkDuplicatedEmailParamsSchema } from './schemas/check-duplicated-email.schema.js';
 import { STATUS } from '../../common/constants/status.js';
@@ -38,7 +38,7 @@ export default class UsersController {
   };
 
   searchUser = async (request: FastifyRequest, reply: FastifyReply) => {
-    const query = searchUserParamsSchema.parse(request.query);
+    const query = searchUserQuerySchema.parse(request.query);
     const params = searchUserParamsSchema.parse(request.params);
     const result = await this.usersService.searchUser(query, params.nickname);
     reply.code(200).send(result);

--- a/src/v1/apis/users/users.route.ts
+++ b/src/v1/apis/users/users.route.ts
@@ -8,7 +8,11 @@ import {
   editNicknameInputSchema,
   editNicknameResponseSchema,
 } from './schemas/edit-nickname.schema.js';
-import { searchUserParamsSchema, searchUserResponseSchema } from './schemas/search-user.schema.js';
+import {
+  searchUserParamsSchema,
+  searchUserQuerySchema,
+  searchUserResponseSchema,
+} from './schemas/search-user.schema.js';
 import {
   authenticateUserInputSchema,
   authenticateUserResponseSchema,
@@ -95,6 +99,7 @@ export default async function usersRoutes(fastify: FastifyInstance) {
           tags: ['users'],
           description: '유저 검색',
           params: searchUserParamsSchema,
+          querystring: searchUserQuerySchema,
           response: {
             200: searchUserResponseSchema,
           },

--- a/src/v1/apis/users/users.service.ts
+++ b/src/v1/apis/users/users.service.ts
@@ -13,7 +13,7 @@ import {
   editNicknameInputSchema,
   editNicknameResponseSchema,
 } from './schemas/edit-nickname.schema.js';
-import { searchUserResponseSchema } from './schemas/search-user.schema.js';
+import { searchUserQuerySchema, searchUserResponseSchema } from './schemas/search-user.schema.js';
 import {
   authenticateUserInputSchema,
   authenticateUserResponseSchema,
@@ -101,7 +101,10 @@ export default class UsersService {
     };
   }
 
-  async searchUser(nickname: string): Promise<TypeOf<typeof searchUserResponseSchema>> {
+  async searchUser(
+    { status, exceptMe }: TypeOf<typeof searchUserQuerySchema>,
+    nickname: string,
+  ): Promise<TypeOf<typeof searchUserResponseSchema>> {
     const users = await this.userRepository.findByNicknameStartsWith(nickname);
 
     return {

--- a/src/v1/apis/users/users.service.ts
+++ b/src/v1/apis/users/users.service.ts
@@ -19,6 +19,7 @@ import {
 } from './schemas/authenticate-user.schema.js';
 import { getProfileSchema, getProfileResponseSchema } from './schemas/get-profile.schema.js';
 import { Status } from '@prisma/client';
+import { searchUserQuerySchema } from './schemas/search-user.schema.js';
 
 export default class UsersService {
   constructor(
@@ -107,7 +108,7 @@ export default class UsersService {
     nickname,
   }: {
     userId: number;
-    query: { status?: string[]; exceptMe?: number };
+    query: TypeOf<typeof searchUserQuerySchema>;
     nickname: string;
   }) {
     // all: status가 없으면 전체조회, noneFlag: status 배열에 'NONE' 포함 여부

--- a/src/v1/apis/users/users.service.ts
+++ b/src/v1/apis/users/users.service.ts
@@ -13,12 +13,12 @@ import {
   editNicknameInputSchema,
   editNicknameResponseSchema,
 } from './schemas/edit-nickname.schema.js';
-import { searchUserQuerySchema, searchUserResponseSchema } from './schemas/search-user.schema.js';
 import {
   authenticateUserInputSchema,
   authenticateUserResponseSchema,
 } from './schemas/authenticate-user.schema.js';
 import { getProfileSchema, getProfileResponseSchema } from './schemas/get-profile.schema.js';
+import { Status } from '@prisma/client';
 
 export default class UsersService {
   constructor(
@@ -101,17 +101,33 @@ export default class UsersService {
     };
   }
 
-  async searchUser(
-    { status, exceptMe }: TypeOf<typeof searchUserQuerySchema>,
-    nickname: string,
-  ): Promise<TypeOf<typeof searchUserResponseSchema>> {
-    const users = await this.userRepository.findByNicknameStartsWith(nickname);
+  async searchUser({
+    userId,
+    query: { status, exceptMe },
+    nickname,
+  }: {
+    userId: number;
+    query: { status?: string[]; exceptMe?: number };
+    nickname: string;
+  }) {
+    // all: status가 없으면 전체조회, noneFlag: status 배열에 'NONE' 포함 여부
+    const all = status === undefined;
+    const noneFlag = status?.includes('NONE') ?? false;
+    // 실제 사용 가능한 status만 필터
+    const realStatuses = status?.filter((s) => s !== 'NONE') as Status[] | undefined;
+
+    const users = await this.userRepository.findByNicknameStartsWith({
+      nickname,
+      userId,
+      exceptMe,
+      all,
+      noneFlag,
+      statuses: realStatuses,
+    });
 
     return {
       status: STATUS.SUCCESS,
-      data: {
-        users,
-      },
+      data: { users },
     };
   }
 

--- a/src/v1/apis/users/users.service.ts
+++ b/src/v1/apis/users/users.service.ts
@@ -114,7 +114,6 @@ export default class UsersService {
 
   async checkDuplicatedEmail(email: string): Promise<boolean> {
     const foundEmail = await this.userRepository.findByEmail(email);
-    console.log('foundEmail', foundEmail);
     if (foundEmail) {
       throw new ConflictException('이미 존재하는 이메일입니다.');
     }

--- a/src/v1/kafka/consumers/user-status.topic.handler.ts
+++ b/src/v1/kafka/consumers/user-status.topic.handler.ts
@@ -26,6 +26,9 @@ export default class UserStatusTopicHandler implements KafkaTopicHandler {
     const { userId, status } = message;
 
     await redis.set(`user:${userId}:status`, status);
-    this.statusNamespace.to(`user-status-${userId}`).emit('friend-status', { friendId: userId, status });
+    this.statusNamespace.to(`user-status-${userId}`).emit('friend-status', {
+      friendId: userId,
+      status,
+    });
   }
 }

--- a/src/v1/storage/database/interfaces/user.repository.interface.ts
+++ b/src/v1/storage/database/interfaces/user.repository.interface.ts
@@ -4,7 +4,7 @@ import { BaseRepositoryInterface } from './base.repository.interface.js';
 export type FindUsersInput = {
   nickname: string;
   userId?: number;
-  exceptMe?: number; // 0: false, 1: true
+  exceptMe?: boolean; // 0: false, 1: true
   all: boolean;
   noneFlag: boolean; // true면 '친구가 없는' 경우
   statuses?: Status[]; // 실제 조회할 상태 배열

--- a/src/v1/storage/database/interfaces/user.repository.interface.ts
+++ b/src/v1/storage/database/interfaces/user.repository.interface.ts
@@ -1,11 +1,20 @@
-import { Prisma, User } from '@prisma/client';
+import { Prisma, Status, User } from '@prisma/client';
 import { BaseRepositoryInterface } from './base.repository.interface.js';
+
+export type FindUsersInput = {
+  nickname: string;
+  userId?: number;
+  exceptMe?: number; // 0: false, 1: true
+  all: boolean;
+  noneFlag: boolean; // true면 '친구가 없는' 경우
+  statuses?: Status[]; // 실제 조회할 상태 배열
+};
 
 export default interface UserRepositoryInterface
   extends BaseRepositoryInterface<User, Prisma.UserCreateInput, Prisma.UserUpdateInput> {
   findByEmail(email: string): Promise<User | null>;
 
-  findByNicknameStartsWith(nickname: string): Promise<User[]>;
+  findByNicknameStartsWith(input: FindUsersInput): Promise<User[]>;
 
   findByNickname(nickname: string): Promise<User | null>;
 }

--- a/src/v1/storage/database/prisma/user.repository.ts
+++ b/src/v1/storage/database/prisma/user.repository.ts
@@ -1,5 +1,7 @@
 import { Prisma, PrismaClient, User } from '@prisma/client';
-import UserRepositoryInterface from '../interfaces/user.repository.interface.js';
+import UserRepositoryInterface, {
+  FindUsersInput,
+} from '../interfaces/user.repository.interface.js';
 
 export default class UserRepositoryPrisma implements UserRepositoryInterface {
   constructor(private readonly prisma: PrismaClient) {}
@@ -28,13 +30,43 @@ export default class UserRepositoryPrisma implements UserRepositoryInterface {
     return this.prisma.user.update({ where: { id }, data });
   }
 
-  findByNicknameStartsWith(nickname: string): Promise<User[]> {
+  async findByNicknameStartsWith({
+    nickname,
+    userId,
+    exceptMe,
+    all,
+    noneFlag,
+    statuses,
+  }: FindUsersInput): Promise<User[]> {
+    // 공통 where: 닉네임, 자신 제외
+    const where: Prisma.UserWhereInput = {
+      nickname: { startsWith: nickname },
+      ...(exceptMe ? { id: { not: userId } } : {}),
+    };
+    console.log('noneFlag', noneFlag, 'userId', userId, 'all', all, 'statuses', statuses);
+    if (!all && userId != null) {
+      if (noneFlag) {
+        // 친구 관계가 전혀 없는 유저
+        where.friendOf = {
+          none: {
+            userId: userId,
+          },
+        };
+      } else if (statuses && statuses.length > 0) {
+        // 특정 상태의 친구만 포함
+        where.friendOf = {
+          some: {
+            userId: userId,
+            status: {
+              in: statuses,
+            },
+          },
+        };
+      }
+    }
+
     return this.prisma.user.findMany({
-      where: {
-        nickname: {
-          startsWith: nickname,
-        },
-      },
+      where,
       take: 10,
     });
   }

--- a/test/v1/apis/users/users.service.spec.ts
+++ b/test/v1/apis/users/users.service.spec.ts
@@ -157,7 +157,32 @@ describe('유저 검색', () => {
     ];
     userRepository.findByNicknameStartsWith = vi.fn().mockResolvedValue(mockUsers);
 
-    const result = await usersService.searchUser('test');
+    const result = await usersService.searchUser({
+      userId: 3,
+      nickname: 'test',
+      query: {},
+    });
+
+    expect(result.status).toBe(STATUS.SUCCESS);
+    expect(result.data).toBeDefined();
+    expect(result.data!.users.length).toBe(2);
+    expect(result.data!.users[0].nickname).toMatch(/^test/);
+  });
+
+  it('query에 None이 들어갈 경우', async () => {
+    const mockUsers = [
+      { id: 1, nickname: 'test1' },
+      { id: 2, nickname: 'test2' },
+    ];
+    userRepository.findByNicknameStartsWith = vi.fn().mockResolvedValue(mockUsers);
+
+    const result = await usersService.searchUser({
+      userId: 3,
+      nickname: 'test',
+      query: {
+        status: ['NONE'],
+      },
+    });
 
     expect(result.status).toBe(STATUS.SUCCESS);
     expect(result.data).toBeDefined();


### PR DESCRIPTION
## 🔗 반영 브랜치

#26 [feature/26-유저검색-api-수정](https://github.com/42-Gang/user-server/compare/dev...feature/26-%EC%9C%A0%EC%A0%80%EA%B2%80%EC%83%89-api-%EC%88%98%EC%A0%95?expand=1) -> dev

## 📝 작업 내용

- 유저검색시 query를 설정하여 필터링을 할 수 있도록 하였습니다.
- 쿼리의 내용은 다음과 같습니다.
- <img width="721" alt="image" src="https://github.com/user-attachments/assets/9ab773c7-6754-42ce-9ea7-fd15751e562f" />
- `NONE` 은 아무 관계도 아닌 상대를 말합니다.
- status에 아무런 입력값을 주지 않으면 모든 유저에 대한 결과를 받아올 수 있습니다.
- `exceptMe` 가 true일 경우 자신은 결과에서 제외됩니다.