### PR TITLE
[FIX] 친구 추가 시 상대방의 상태 업데이트 제거

### DIFF
--- a/src/v1/kafka/consumers/friend.topic.handler.ts
+++ b/src/v1/kafka/consumers/friend.topic.handler.ts
@@ -30,11 +30,6 @@ export default class FriendTopicHandler implements KafkaTopicHandler {
         status: userStatus.ONLINE,
         timestamp: new Date().toISOString(),
       });
-      await this.userStatusTopicHandler.handleUserStatusMessage({
-        userId: Number(data.userBId),
-        status: userStatus.ONLINE,
-        timestamp: new Date().toISOString(),
-      });
 
       await this.handleFriendAddMessage(data);
     }


### PR DESCRIPTION
## 📝 작업 내용

- 친구 추가 완료 이벤트(ADDED) 발생시 유저의 상태를 온라인으로 변환하는 로직에 버그가 존재했습니다.
- 친구 추가 완료시 친구를 보낸 사용자, 친구요청을 받은 사용자가 있는데, 친구요청을 받은 사용자가 수락을 하면 두 사용자 모두에게 온라인으로 변환하는 로직이 문제가 되었습니다.
- 따라서 친구 수락을 누른 사용자만 온라인으로 변경하도록 수정하였습니다.