### PR TITLE
[REFACTOR] 유저 검색 시 none과 다른 상태가 동시에 검색이 가능하도록 수정

### DIFF
--- a/src/v1/apis/users/schemas/search-user.schema.ts
+++ b/src/v1/apis/users/schemas/search-user.schema.ts
@@ -25,14 +25,6 @@ export const searchUserQuerySchema = z.object({
           NONE: 'NONE',
         }),
       )
-      .superRefine((val, ctx) => {
-        if (val.includes('NONE') && 1 < val.length) {
-          ctx.addIssue({
-            code: z.ZodIssueCode.custom,
-            message: '상태를 NONE으로 설정할 경우 다른 상태를 설정할 수 없습니다.',
-          });
-        }
-      })
       .optional(),
   ),
   exceptMe: z.preprocess((val) => {

--- a/src/v1/storage/database/prisma/user.repository.ts
+++ b/src/v1/storage/database/prisma/user.repository.ts
@@ -45,23 +45,31 @@ export default class UserRepositoryPrisma implements UserRepositoryInterface {
     };
     console.log('noneFlag', noneFlag, 'userId', userId, 'all', all, 'statuses', statuses);
     if (!all && userId != null) {
+      const orCondition: Prisma.UserWhereInput[] = [];
+
       if (noneFlag) {
-        // 친구 관계가 전혀 없는 유저
-        where.friendOf = {
-          none: {
-            userId: userId,
-          },
-        };
-      } else if (statuses && statuses.length > 0) {
-        // 특정 상태의 친구만 포함
-        where.friendOf = {
-          some: {
-            userId: userId,
-            status: {
-              in: statuses,
+        orCondition.push({
+          friendOf: {
+            none: {
+              userId: userId,
             },
           },
-        };
+        });
+      } 
+      if (statuses && statuses.length > 0) {
+        orCondition.push({
+          friendOf: {
+            some: {
+              userId: userId,
+              status: {
+                in: statuses,
+              },
+            },
+          },
+        });
+      }
+      if (orCondition.length > 0) {
+        where.OR = orCondition;
       }
     }
 


### PR DESCRIPTION
## 🔗 반영 브랜치

refactor/71-사용자-검색-로직-수정 -> dev

## 📝 작업 내용

- 유저 검색에 사용되는 schema를 수정하였습니다.
- 유저 검색 서비스 함수에서 사용되는 repository 함수 내용 수정하였습니다.
