### PR TITLE
[BUG] 79 oauth 회원가입 시에 닉네임 규정 준수

### DIFF
--- a/src/v1/apis/users/users.service.ts
+++ b/src/v1/apis/users/users.service.ts
@@ -242,7 +242,7 @@ export default class UsersService {
   }
 
   private generateRandomSuffix(length: number): string {
-    const ALPHABETS = 'abcdefghijklmnopqrstuvwxyz';
+    const ALPHABETS = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789';
     return Array.from(
       { length },
       () => ALPHABETS[Math.floor(Math.random() * ALPHABETS.length)],
@@ -258,10 +258,11 @@ export default class UsersService {
     let suffixLength = 0;
     let attempts = 0;
 
-    while (attempts < MAX_ATTEMPTS && (await this.userRepository.findByNickname(finalNickname))) {
+    for (let i = 0; i < MAX_LENGTH; i += 1) {
+      if (!await this.userRepository.findByNickname(finalNickname)) {
+        return finalNickname
+      }
       suffixLength += 1;
-      attempts += 1;
-
       const randomSuffix = this.generateRandomSuffix(suffixLength);
       baseNickname = base.slice(0, Math.max(0, MAX_LENGTH - suffixLength));
       finalNickname = `${baseNickname}${randomSuffix}`;

--- a/src/v1/apis/users/users.service.ts
+++ b/src/v1/apis/users/users.service.ts
@@ -241,7 +241,7 @@ export default class UsersService {
     };
   }
 
-  private async generateRandomSuffix(length: number): Promise<string> {
+  private generateRandomSuffix(length: number): string {
     const ALPHABETS = 'abcdefghijklmnopqrstuvwxyz';
     return Array.from(
       { length },
@@ -262,7 +262,7 @@ export default class UsersService {
     while (await this.userRepository.findByNickname(finalNickname)) {
       suffixLength += 1;
 
-      const randomSuffix = await this.generateRandomSuffix(suffixLength);
+      const randomSuffix = this.generateRandomSuffix(suffixLength);
       baseNickname = nickname.slice(0, MAX_LENGTH - suffixLength);
       finalNickname = `${baseNickname}${randomSuffix}`;
     }

--- a/src/v1/apis/users/users.service.ts
+++ b/src/v1/apis/users/users.service.ts
@@ -263,7 +263,7 @@ export default class UsersService {
       suffixLength += 1;
 
       const randomSuffix = this.generateRandomSuffix(suffixLength);
-      baseNickname = nickname.slice(0, MAX_LENGTH - suffixLength);
+      baseNickname = nickname.slice(0, Math.max(0, MAX_LENGTH - suffixLength));
       finalNickname = `${baseNickname}${randomSuffix}`;
     }
 

--- a/src/v1/apis/users/users.service.ts
+++ b/src/v1/apis/users/users.service.ts
@@ -258,18 +258,17 @@ export default class UsersService {
     let suffixLength = 0;
     let attempts = 0;
 
-    for (let i = 0; i < MAX_LENGTH; i += 1) {
+    for (let i = 0; i <= MAX_LENGTH; i += 1) {
       if (!await this.userRepository.findByNickname(finalNickname)) {
         return finalNickname
+      }
+      if (attempts == MAX_ATTEMPTS) {
+        throw new ConflictException('고유 닉네임 생성에 실패하였습니다.');
       }
       suffixLength += 1;
       const randomSuffix = this.generateRandomSuffix(suffixLength);
       baseNickname = base.slice(0, Math.max(0, MAX_LENGTH - suffixLength));
       finalNickname = `${baseNickname}${randomSuffix}`;
-    }
-
-    if (attempts >= MAX_ATTEMPTS && (await this.userRepository.findByNickname(finalNickname))) {
-      throw new ConflictException('고유 닉네임 생성에 실패하였습니다.');
     }
 
     return finalNickname;

--- a/src/v1/apis/users/users.service.ts
+++ b/src/v1/apis/users/users.service.ts
@@ -245,9 +245,21 @@ export default class UsersService {
     email: string,
     nickname: string,
   ): Promise<TypeOf<typeof createOauthUserResponseSchema>> {
+    const ALPHABETS = 'abcdefghijklmnopqrstuvwxyz';
+    const MAX_LENGTH = 8;
+  
+    if (nickname.length > MAX_LENGTH) {
+      nickname = nickname.slice(0, MAX_LENGTH);
+    }
+
+    let suffixLength = 0;
     let userWithSameNickname = await this.userRepository.findByNickname(nickname);
     while (userWithSameNickname) {
-      const randomSuffix = Math.floor(Math.random() * 100000 + 1);
+      suffixLength += 1;
+      const randomSuffix = Array.from({ length: suffixLength }, () =>
+        ALPHABETS[Math.floor(Math.random() * ALPHABETS.length)]
+      ).join('');
+      nickname = nickname.slice(0, MAX_LENGTH - suffixLength);
       const newNickname = `${nickname}${randomSuffix}`;
       userWithSameNickname = await this.userRepository.findByNickname(newNickname);
       if (!userWithSameNickname) {

--- a/src/v1/apis/users/users.service.ts
+++ b/src/v1/apis/users/users.service.ts
@@ -243,10 +243,12 @@ export default class UsersService {
 
   private generateRandomSuffix(length: number): string {
     const ALPHABETS = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789';
-    return Array.from(
-      { length },
-      () => ALPHABETS[Math.floor(Math.random() * ALPHABETS.length)],
-    ).join('');
+    let result = '';
+    for (let i = 0; i < length; i++) {
+      const randomIndex = Math.floor(Math.random() * ALPHABETS.length);
+      result += ALPHABETS[randomIndex];
+    }
+    return result;
   }
 
   private async generateUniqueNickname(base: string): Promise<string> {

--- a/src/v1/apis/users/users.service.ts
+++ b/src/v1/apis/users/users.service.ts
@@ -251,17 +251,14 @@ export default class UsersService {
 
   private async generateUniqueNickname(base: string): Promise<string> {
     const MAX_LENGTH = 8;
-    const  MAX_ATTEMPTS = 10;
+    const MAX_ATTEMPTS = 10;
     let baseNickname = base.slice(0, MAX_LENGTH);
     let finalNickname = baseNickname;
 
     let suffixLength = 0;
     let attempts = 0;
 
-    while (
-      attempts < MAX_ATTEMPTS &&
-      await this.userRepository.findByNickname(finalNickname)
-    ) {
+    while (attempts < MAX_ATTEMPTS && (await this.userRepository.findByNickname(finalNickname))) {
       suffixLength += 1;
       attempts += 1;
 
@@ -270,16 +267,12 @@ export default class UsersService {
       finalNickname = `${baseNickname}${randomSuffix}`;
     }
 
-    if (
-      attempts >= MAX_ATTEMPTS &&
-      await this.userRepository.findByNickname(finalNickname)
-    ) {
+    if (attempts >= MAX_ATTEMPTS && (await this.userRepository.findByNickname(finalNickname))) {
       throw new ConflictException('고유 닉네임 생성에 실패하였습니다.');
     }
 
     return finalNickname;
   }
-
 
   async createOAuthUser(
     email: string,
@@ -301,8 +294,7 @@ export default class UsersService {
         userId: user.id,
       },
     };
-}
-
+  }
 
   async checkOAuthUserExistence(
     email: string,


### PR DESCRIPTION
## 🔗 반영 브랜치

bug/79-oauth-회원가입-시에-닉네임-규정-준수 -> dev

## 📝 작업 내용

닉네임 8자 규정 맞춰서 생성하도록 수정
- 구글에서 가져온 사용자 명이 8자를 넘는다면 자름
- 중복이 없을 때까지 뒤부터 랜덤한 알파벳으로 대체
- 닉네임 생성 최대 시도 횟수 (10번)을 넘겼을 시에 ConflictException 발생
