### PR TITLE
[FEATURE] 프로필 조회시, 게임통계 포함

### DIFF
--- a/src/plugins/container.ts
+++ b/src/plugins/container.ts
@@ -23,6 +23,8 @@ export async function setDiContainer(server: FastifyInstance) {
 
   diContainer.register({
     fileServerUrl: asValue(process.env.FILE_SERVER_URL),
+    gameServerUrl: asValue(process.env.GAME_SERVER_URL),
+    userServerUrl: asValue(process.env.USER_SERVER_URL),
   });
 
   const NODE_EXTENSION = process.env.NODE_ENV == 'dev' ? 'ts' : 'js';
@@ -31,6 +33,7 @@ export async function setDiContainer(server: FastifyInstance) {
       `./**/src/**/*.repository.${NODE_EXTENSION}`,
       `./**/src/**/*.controller.${NODE_EXTENSION}`,
       `./**/src/**/*.service.${NODE_EXTENSION}`,
+      `./**/src/**/*.service.client.${NODE_EXTENSION}`,
     ],
     {
       esModules: true,

--- a/src/v1/apis/users/schemas/create-user.schema.ts
+++ b/src/v1/apis/users/schemas/create-user.schema.ts
@@ -1,4 +1,4 @@
-import { exceptedSensitiveFields, userSchema } from './users.schema.js';
+import { safeUserSchema, userSchema } from './users.schema.js';
 import { createResponseSchema } from '../../../common/schema/core.schema.js';
 import { z } from 'zod';
 
@@ -20,4 +20,4 @@ export const createUserInputSchema = userSchema
     password: passwordSchema,
   });
 
-export const createUserResponseSchema = createResponseSchema(exceptedSensitiveFields);
+export const createUserResponseSchema = createResponseSchema(safeUserSchema);

--- a/src/v1/apis/users/schemas/edit-nickname.schema.ts
+++ b/src/v1/apis/users/schemas/edit-nickname.schema.ts
@@ -1,8 +1,8 @@
-import { exceptedSensitiveFields, userSchema } from './users.schema.js';
+import { safeUserSchema, userSchema } from './users.schema.js';
 import { createResponseSchema } from '../../../common/schema/core.schema.js';
 
 export const editNicknameInputSchema = userSchema.pick({
   nickname: true,
 });
 
-export const editNicknameResponseSchema = createResponseSchema(exceptedSensitiveFields);
+export const editNicknameResponseSchema = createResponseSchema(safeUserSchema);

--- a/src/v1/apis/users/schemas/get-profile.schema.ts
+++ b/src/v1/apis/users/schemas/get-profile.schema.ts
@@ -1,7 +1,7 @@
 import { createResponseSchema } from '../../../common/schema/core.schema.js';
-import { exceptedSensitiveFields } from './users.schema.js';
+import { safeUserSchema } from './users.schema.js';
 
-export const getProfileSchema = exceptedSensitiveFields.omit({
+export const getProfileSchema = safeUserSchema.omit({
   createdAt: true,
   updatedAt: true,
 });

--- a/src/v1/apis/users/schemas/get-user.schema.ts
+++ b/src/v1/apis/users/schemas/get-user.schema.ts
@@ -1,12 +1,12 @@
 import { createResponseSchema } from '../../../common/schema/core.schema.js';
-import { exceptedSensitiveFields, userSchema } from './users.schema.js';
+import { safeUserSchema, userSchema } from './users.schema.js';
 
 export const getUserParamsSchema = userSchema.pick({
   id: true,
 });
 
 export const getUserResponseSchema = createResponseSchema(
-  exceptedSensitiveFields.omit({
+  safeUserSchema.omit({
     createdAt: true,
     updatedAt: true,
   }),

--- a/src/v1/apis/users/schemas/get-user.schema.ts
+++ b/src/v1/apis/users/schemas/get-user.schema.ts
@@ -1,13 +1,20 @@
 import { createResponseSchema } from '../../../common/schema/core.schema.js';
 import { safeUserSchema, userSchema } from './users.schema.js';
+import { z } from 'zod';
 
 export const getUserParamsSchema = userSchema.pick({
   id: true,
 });
 
 export const getUserResponseSchema = createResponseSchema(
-  safeUserSchema.omit({
-    createdAt: true,
-    updatedAt: true,
-  }),
+  safeUserSchema
+    .omit({
+      createdAt: true,
+      updatedAt: true,
+    })
+    .extend({
+      win: z.number(),
+      lose: z.number(),
+      tournament: z.number(),
+    }),
 );

--- a/src/v1/apis/users/schemas/search-user.schema.ts
+++ b/src/v1/apis/users/schemas/search-user.schema.ts
@@ -1,4 +1,4 @@
-import { exceptedSensitiveFields, userSchema } from './users.schema.js';
+import { safeUserSchema, userSchema } from './users.schema.js';
 import { createResponseSchema } from '../../../common/schema/core.schema.js';
 import { z } from 'zod';
 import { Status } from '@prisma/client';
@@ -35,7 +35,7 @@ export const searchUserQuerySchema = z.object({
   }, z.boolean().optional()),
 });
 
-export const searchUserResponseFields = exceptedSensitiveFields.omit({
+export const searchUserResponseFields = safeUserSchema.omit({
   createdAt: true,
   updatedAt: true,
   email: true,

--- a/src/v1/apis/users/schemas/users.schema.ts
+++ b/src/v1/apis/users/schemas/users.schema.ts
@@ -11,7 +11,7 @@ export const userSchema = z.object({
   updatedAt: z.date(),
 });
 
-export const exceptedSensitiveFields = userSchema.omit({
+export const safeUserSchema = userSchema.omit({
   passwordHash: true,
   twoFactorAuth: true,
 });

--- a/src/v1/apis/users/users.service.ts
+++ b/src/v1/apis/users/users.service.ts
@@ -30,6 +30,7 @@ import * as path from 'node:path';
 import { deleteAvatarResponseSchema } from './schemas/delete-avatar.schema.js';
 import { createOauthUserResponseSchema } from './schemas/oauth-create-user.schema.js';
 import { oauthUserExistsResponseSchema } from './schemas/check-oauth-user-existence.schema.js';
+import GameServiceClient from '../../clients/game.service.client.js';
 
 const avatarDefaultUrl = 'avatars-default.png';
 export default class UsersService {
@@ -37,6 +38,7 @@ export default class UsersService {
     private readonly userRepository: UserRepositoryInterface,
     private readonly crypt: typeof bcrypt,
     private readonly fileService: FileService,
+    private readonly gameServiceClient: GameServiceClient,
   ) {}
 
   async createUser(
@@ -93,9 +95,17 @@ export default class UsersService {
   async getUser(id: number): Promise<TypeOf<typeof getUserResponseSchema>> {
     const user = await this.getProfileData(id);
 
+    const duelStats = await this.gameServiceClient.getDuelStats(id);
+    const tournamentStats = await this.gameServiceClient.getTournamentStats(id);
+
     return {
       status: STATUS.SUCCESS,
-      data: { ...user, win: 0, lose: 0, tournament: 0 },
+      data: {
+        ...user,
+        win: duelStats.summary.wins,
+        lose: duelStats.summary.losses,
+        tournament: tournamentStats.summary.wins,
+      },
     };
   }
 

--- a/src/v1/apis/users/users.service.ts
+++ b/src/v1/apis/users/users.service.ts
@@ -95,7 +95,7 @@ export default class UsersService {
 
     return {
       status: STATUS.SUCCESS,
-      data: user,
+      data: { ...user, win: 0, lose: 0, tournament: 0 },
     };
   }
 

--- a/src/v1/apis/users/users.service.ts
+++ b/src/v1/apis/users/users.service.ts
@@ -95,8 +95,10 @@ export default class UsersService {
   async getUser(id: number): Promise<TypeOf<typeof getUserResponseSchema>> {
     const user = await this.getProfileData(id);
 
-    const duelStats = await this.gameServiceClient.getDuelStats(id);
-    const tournamentStats = await this.gameServiceClient.getTournamentStats(id);
+    const [duelStats, tournamentStats] = await Promise.all([
+      this.gameServiceClient.getDuelStats(id),
+      this.gameServiceClient.getTournamentStats(id),
+    ]);
 
     return {
       status: STATUS.SUCCESS,

--- a/src/v1/clients/game.service.client.ts
+++ b/src/v1/clients/game.service.client.ts
@@ -1,5 +1,6 @@
 import { GotClient } from '../../plugins/http.client.js';
 import { z } from 'zod';
+import { ServiceUnavailableException } from '../common/exceptions/core.error.js';
 
 enum GameMode {
   DUEL = 'DUEL',
@@ -92,7 +93,7 @@ export default class GameServiceClient {
     const response = await this.getStats(userId, GameMode.DUEL);
 
     if (response.statusCode !== 200) {
-      throw new Error(`Failed to fetch duel stats: ${response.statusCode}`);
+      throw new ServiceUnavailableException(`Failed to fetch duel stats: ${response.statusCode}`);
     }
 
     return ZDuelData.parse(response.body.data);
@@ -102,7 +103,9 @@ export default class GameServiceClient {
     const response = await this.getStats(userId, GameMode.TOURNAMENT);
 
     if (response.statusCode !== 200) {
-      throw new Error(`Failed to fetch duel stats: ${response.statusCode}`);
+      throw new ServiceUnavailableException(
+        `Failed to fetch tournament stats: ${response.statusCode}`,
+      );
     }
 
     return ZTournamentData.parse(response.body.data);

--- a/src/v1/clients/game.service.client.ts
+++ b/src/v1/clients/game.service.client.ts
@@ -1,0 +1,110 @@
+import { GotClient } from '../../plugins/http.client.js';
+import { z } from 'zod';
+
+enum GameMode {
+  DUEL = 'DUEL',
+  TOURNAMENT = 'TOURNAMENT',
+}
+
+export enum TournamentResultEnum {
+  WIN = 'WIN',
+  LOSS = 'LOSS',
+}
+
+export const ZTournamentHistoryItem = z.object({
+  tournamentId: z.number().int().positive(),
+  rounds: z.number().int().positive(),
+  participants: z
+    .array(
+      z.object({
+        id: z.number().int().nonnegative(),
+        nickname: z.string().min(1),
+      }),
+    )
+    .min(1),
+  myResult: z.nativeEnum(TournamentResultEnum),
+});
+
+export const ZDuelHistoryItem = z.object({
+  date: z.string().datetime(),
+  player1: z.object({
+    id: z.number().int().nonnegative(),
+    nickname: z.string().min(1),
+  }),
+  player2: z.object({
+    id: z.number().int().nonnegative(),
+    nickname: z.string().min(1),
+  }),
+  result: z.object({
+    winnerId: z.number().int().nonnegative(),
+    scores: z.object({
+      player1: z.number().int().min(0),
+      player2: z.number().int().min(0),
+    }),
+  }),
+});
+
+export const ZTournamentData = z.object({
+  summary: z.object({
+    wins: z.number().int().min(0),
+    losses: z.number().int().min(0),
+  }),
+  history: z.array(ZTournamentHistoryItem),
+});
+
+export const ZDuelData = z.object({
+  summary: z.object({
+    wins: z.number().int().min(0),
+    losses: z.number().int().min(0),
+  }),
+  history: z.array(ZDuelHistoryItem),
+});
+
+export default class GameServiceClient {
+  constructor(
+    private readonly httpClient: GotClient,
+    private readonly gameServerUrl: string,
+  ) {
+    if (!gameServerUrl) {
+      throw new Error('gameServerUrl is required and must be a non-empty string');
+    }
+  }
+
+  private getStats(userId: number, mode: GameMode) {
+    return this.httpClient.requestJson<{
+      message: string;
+      data: object;
+    }>({
+      url: `http://${this.gameServerUrl}/api/v1/game/stats/${userId}`,
+      queryParams: {
+        mode,
+      },
+      method: 'GET',
+      headers: {
+        'x-internal': 'true',
+        'x-authenticated': 'true',
+        'x-user-id': userId.toString(),
+      },
+    });
+  }
+
+  async getDuelStats(userId: number): Promise<z.infer<typeof ZDuelData>> {
+    const response = await this.getStats(userId, GameMode.DUEL);
+
+    if (response.statusCode !== 200) {
+      throw new Error(`Failed to fetch duel stats: ${response.statusCode}`);
+    }
+
+    return ZDuelData.parse(response.body.data);
+  }
+
+  async getTournamentStats(userId: number): Promise<z.infer<typeof ZTournamentData>> {
+    const response = await this.getStats(userId, GameMode.TOURNAMENT);
+
+    if (response.statusCode !== 200) {
+      throw new Error(`Failed to fetch duel stats: ${response.statusCode}`);
+    }
+
+    return ZTournamentData.parse(response.body.data);
+  }
+}

--- a/src/v1/common/exceptions/core.error.ts
+++ b/src/v1/common/exceptions/core.error.ts
@@ -55,3 +55,9 @@ export class NotImplementedException extends HttpException {
     super(501, message || '기능 미구현');
   }
 }
+
+export class ServiceUnavailableException extends HttpException {
+  constructor(message: string) {
+    super(503, message || '서비스 이용 불가');
+  }
+}


### PR DESCRIPTION
## 📝 작업 내용

- 기존 `/api/v1/users/:id` API에서 게임 관련 통계 내용을 추가하였습니다.
- 특정 사용자의 기본정보와, 1:1 게임 이긴/진 횟수와 토너먼트 승리 횟수를 포함하였습니다.